### PR TITLE
Update 841101-wpscan_rules.xml

### DIFF
--- a/rules/841101-wpscan_rules.xml
+++ b/rules/841101-wpscan_rules.xml
@@ -1,4 +1,5 @@
-  <rule id="841101" level="7">
+<group name="wpscan,web,accesslog,">
+<rule id="841101" level="7">
     <if_sid>800001,800002,31100</if_sid>
     <id>^4</id>
     <url>wp-includes|wp-login|wp-admin|wp-|wordpress|xmlrpc.php</url>
@@ -16,3 +17,4 @@
     </mitre>
     <group>web_scan,recon,attack,pci_dss_6.5,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
+</group>


### PR DESCRIPTION
adding Group Name

wazuh-analysisd: CRITICAL: (1220): Error loading the rules: 'etc/rules/841101-wpscan_rules.xml'.